### PR TITLE
App | product url

### DIFF
--- a/server/products.js
+++ b/server/products.js
@@ -4,7 +4,7 @@ const { baseUrl, authorization } = require('./server-config');
 
 const filterProduct = (products, name) => {
   let foundProduct = {};
-  const formattedName = name.toLowerCase().replace('-', ' ');
+  const formattedName = name.toLowerCase().replace(/-/g, ' ');
   products.forEach((product) => {
     if (product.name.toLowerCase() === formattedName) {
       foundProduct = product;
@@ -18,9 +18,9 @@ const getProduct = (productShortName, cb) => {
     .get(`${baseUrl}/products`, {
       headers: { Authorization: authorization },
     })
-    .then((response) =>
-      cb(null, filterProduct(response.data, productShortName))
-    )
+    .then((response) => {
+      cb(null, filterProduct(response.data, productShortName));
+    })
     .catch((err) => cb(err));
 };
 

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
-import { ProductIdContext } from './context/ProductIdContext';
+import ProductIdContext from './context/ProductIdContext';
 import Overview from './overview/Overview';
 import QA from './q&a/QA';
 import Ratings from './ratings/Ratings';

--- a/src/components/context/ProductIdContext.jsx
+++ b/src/components/context/ProductIdContext.jsx
@@ -1,6 +1,8 @@
 import { createContext } from 'react';
 
-export const ProductIdContext = createContext({
+const ProductIdContext = createContext({
   productId: null,
   setProductId: () => {},
 });
+
+export default ProductIdContext;

--- a/src/components/overview/Overview.jsx
+++ b/src/components/overview/Overview.jsx
@@ -6,7 +6,7 @@ import AddToCart from './AddToCart/AddToCart';
 import ProductInformation from './ProductInformation/ProductInformation';
 import StyleSelector from './StyleSelector/StyleSelector';
 import ProductTextOverview from './ProductTextOverview/ProductTextOverview';
-import { ProductIdContext } from '../context/ProductIdContext';
+import ProductIdContext from '../context/ProductIdContext';
 
 const Overview = () => {
   const { productId } = useContext(ProductIdContext);
@@ -36,9 +36,5 @@ const Overview = () => {
     </div>
   );
 };
-
-
-
-
 
 export default Overview;

--- a/src/components/q&a/QuestionsList/AddQuestionsButton/AddQuestionsButton.jsx
+++ b/src/components/q&a/QuestionsList/AddQuestionsButton/AddQuestionsButton.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import axios from 'axios';
-import { ProductIdContext } from '../../../context/ProductIdContext';
+import ProductIdContext from '../../../context/ProductIdContext';
 import styles from './AddQuestionsButton.css';
 
 const AddQuestionsButton = function () {

--- a/src/components/q&a/QuestionsList/IndividualQuestion/Answer/Answer.jsx
+++ b/src/components/q&a/QuestionsList/IndividualQuestion/Answer/Answer.jsx
@@ -3,7 +3,7 @@ import axios from 'axios';
 import PropTypes from 'prop-types';
 import Images from './Images/Images';
 import styles from './Answer.css';
-import { ProductIdContext } from '../../../../context/ProductIdContext';
+import ProductIdContext from '../../../../context/ProductIdContext';
 
 const Answer = function ({
   body,

--- a/src/components/q&a/QuestionsList/IndividualQuestion/IndividualQuestion.jsx
+++ b/src/components/q&a/QuestionsList/IndividualQuestion/IndividualQuestion.jsx
@@ -3,7 +3,7 @@ import axios from 'axios';
 import PropTypes from 'prop-types';
 import Answer from './Answer/Answer';
 import styles from './IndividualQuestion.css';
-import { ProductIdContext } from '../../../context/ProductIdContext';
+import ProductIdContext from '../../../context/ProductIdContext';
 
 const IndividualQuestion = function ({
   body,

--- a/src/components/q&a/QuestionsList/QuestionsList.jsx
+++ b/src/components/q&a/QuestionsList/QuestionsList.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import IndividualQuestion from './IndividualQuestion/IndividualQuestion';
 import BottomBar from './BottomBar/BottomBar';
 import styles from './QuestionsList.css';
-import { ProductIdContext } from '../../context/ProductIdContext';
+import ProductIdContext from '../../context/ProductIdContext';
 import AddQuestionsButton from './AddQuestionsButton/AddQuestionsButton';
 
 const QuestionsList = function ({

--- a/src/components/ratings/RatingDetail/RatingList/RatingList.jsx
+++ b/src/components/ratings/RatingDetail/RatingList/RatingList.jsx
@@ -3,7 +3,7 @@ import axios from 'axios';
 import PropTypes from 'prop-types';
 import styles from './RatingList.css';
 import RatingListEntry from './RatingListEntry/RatingListEntry';
-import { ProductIdContext } from '../../../context/ProductIdContext';
+import ProductIdContext from '../../../context/ProductIdContext';
 import ActionButtons from './ActionButtons/ActionButtons';
 import ModalForm from './ModalForm/ModalForm';
 

--- a/src/components/ratings/RatingSummary/Bars/Bars.jsx
+++ b/src/components/ratings/RatingSummary/Bars/Bars.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useContext, useState } from 'react';
 import axios from 'axios';
 import styles from './Bars.css';
 import Slider from './Bar/Bar';
-import { ProductIdContext } from '../../../context/ProductIdContext';
+import ProductIdContext from '../../../context/ProductIdContext';
 
 export default function Sliders() {
   const { productId } = useContext(ProductIdContext);

--- a/src/components/ratings/RatingSummary/Recommendations/Recommendations.jsx
+++ b/src/components/ratings/RatingSummary/Recommendations/Recommendations.jsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useState } from 'react';
 import axios from 'axios';
 import styles from './Recommendations.css';
-import { ProductIdContext } from '../../../context/ProductIdContext';
+import ProductIdContext from '../../../context/ProductIdContext';
 
 export default function Recommendations() {
   const { productId } = useContext(ProductIdContext);

--- a/src/components/ratings/RatingSummary/Sliders/Sliders.jsx
+++ b/src/components/ratings/RatingSummary/Sliders/Sliders.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useContext } from 'react';
 import axios from 'axios';
 import Slider from './Slider/Slider';
 import styles from './Sliders.css';
-import { ProductIdContext } from '../../../context/ProductIdContext';
+import ProductIdContext from '../../../context/ProductIdContext';
 
 export default function Sliders() {
   const [characteristics, setCharacteristics] = useState({});

--- a/src/components/ratings/RatingSummary/Stars/Stars.jsx
+++ b/src/components/ratings/RatingSummary/Stars/Stars.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useContext } from 'react';
 import axios from 'axios';
 import styles from './Stars.css';
 import StarGraphic from './StarGraphic/StarGraphic';
-import { ProductIdContext } from '../../../context/ProductIdContext';
+import ProductIdContext from '../../../context/ProductIdContext';
 
 export default function Stars() {
   const [stars, setStars] = useState(null);


### PR DESCRIPTION
- Fixes bug for products in URL that have more than two dashes; noticed only first dash was being replaced by a space, so would not find the matching product from Atelier API
- E.g., _bright-future-sunglasses_ was becoming _bright future-sunglasses_, which would not match data in backend
- This minor change uses a regex expression to globally replace dashes in a string
- Using `replace('-',...)` will only replace the first dash in the string; whereas using regex expression `replace(/-/g, ...)` will replace all instances of the dash